### PR TITLE
Решение проблемы с экспортом методов

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -70,6 +70,7 @@ class Client {
         this._api.request(_signal.asJSON());
     }
     close() {
+        debug('closed');
         this._api.close();
     }
     getTimer(_ttl, _sid) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -73,8 +73,10 @@ class Core {
                 var _cid = server.href;
                 if (!this.client.has(_cid)) {
                     this.baseAPI.connect(this, {
-                        url: server.href,
-                    }, debug);
+                        url: server.href
+                    }, (err, res) => {
+                        debug("baseAPI.connect callback", err, res)
+                    });
                 }
             });
         }
@@ -113,6 +115,7 @@ class Core {
         });
 
         this.client.get(_cid).onClose(() => {
+            debug('client disconnected', _cid);
             this.onClientDisconnected(_cid);
         });
 
@@ -219,9 +222,11 @@ class Core {
                 debug('process - await');
             }
         } else {
-            debug('signal - complete');
+            debug('signal - complete', _signal.getResult());
             if (this.client.has(_signal._cid)) {
                 this.client.get(_signal._cid).response(_signal.getResult());
+            } else {
+                debug(`client ${_signal._cid} is not found`)
             }
         }
         _callback();

--- a/lib/core.js
+++ b/lib/core.js
@@ -174,8 +174,9 @@ class Core {
     }
 
     onClientDisconnected(_cid) {
-        debug('remove client: ' + _cid);
-        this.client.delete(_cid);
+        //debug('remove client: ' + _cid);
+        //this.client.delete(_cid);
+        debug(`purge instances from the client: ${_cid}`)
         this.instance.forEach((api, key) => {
             api.from = _.without(api.from, _cid);
             if (api.from.length == 0 && !api.export && api.access != "core") {

--- a/lib/module/index.js
+++ b/lib/module/index.js
@@ -65,7 +65,7 @@ class BaseAPI {
             uid: 'worker'
         }, _.once((_err, _sid, _api) => {
             if (_err) return done(_err);
-
+            debug(`service ${_cid} connected to ${args._url}`);
             env.onClientConnected(
                 _sid, _api, {
                     type: "server",
@@ -81,7 +81,9 @@ class BaseAPI {
             });
         }));
     }
+
     static disconnect(env, args, done) {
+        debug('try to disconnect', args.cid)
         if (env.client.has(args.cid)) {
             env.client.get(args.cid).close();
             env.client.delete(args.cid);

--- a/lib/service.js
+++ b/lib/service.js
@@ -36,28 +36,37 @@ class Service {
 
     connect(_url, _data, _ready) {
         _url = url.parse(_url);
-        var socket = require('socket.io-client')(_url.href, {
-            transports: ['websocket'],
-            query: qs.stringify(_data)
-        });
-        socket.on('connect', _.once(function () {
+        if (!this.socket) {
+            debug('create new socket')
+            this.socket = require('socket.io-client')(_url.href, {
+                transports: ['websocket'],
+                query: qs.stringify(_data)
+            });
+        }
+        this.socket.on('connect', _.once(() => {
             debug(`connected to ${_url.href}`);
-            _ready(null, socket.id, {
-                request: function (msg) { socket.emit('client.request', msg) },
-                response: function (msg) { socket.emit('client.response', msg) },
-                onRequest: function (_cb) { socket.on('server.request', _cb) },
-                onResponse: function (_cb) { socket.on('server.response', _cb) },
-                onClose: function (_cb) { socket.on('disconnect', _cb) },
-                onError: function (_cb) { socket.on('error', _cb) },
-                close: function () { socket.end(); }
+            _ready(null, this.socket.id, {
+                request: (msg) => { this.socket.emit('client.request', msg) },
+                response: (msg) => { this.socket.emit('client.response', msg) },
+                onRequest: (_cb) => { this.socket.on('server.request', _cb) },
+                onResponse: (_cb) => { this.socket.on('server.response', _cb) },
+                onClose: (_cb) => { this.socket.on('disconnect', _cb) },
+                onError: (_cb) => { this.socket.on('error', _cb) },
+                close: () => { this.socket.disconnect(); }
             });
         }));
-        socket.on('error', _.once(function (err) {
-            debug(`Can not connect to ${_url.href}`);
+
+        this.socket.on('reconnect', _.once(() => {
+            debug(`reconnected to ${_url.href}`);
+        }));
+
+        this.socket.on('error', _.once(function (err) {
+            debug(`error: an not connect to ${_url.href}`, err);
             _ready(err);
         }));
-        socket.on('connect_error', _.once(function (err) {
-            debug(`Can not connect to ${_url.href}`);
+
+        this.socket.on('connect_error', _.once(function (err) {
+            debug(`connect error: can not connect to ${_url.href}`, err);
             _ready(err);
         }));
     }
@@ -149,7 +158,7 @@ class Service {
                     onClose: function (_cb) { socket.on('disconnect', _cb) },
                     onError: function (_cb) { socket.on('error', _cb) },
 
-                    close: function () { socket.end(); }
+                    close: function () { socket.disconnect(); }
                 }, {
                     type: "client",
                     host: socket.handshake.address,


### PR DESCRIPTION
fix #8 

суть в том, что когда гейт отваливается, вызывается core#onClientDisconnected и удаляет информацию о клиенте. При этом сокет живет и активно пытается переподключиться. Когда это ему удается, core#onClientConnected не вызывается, т.к. происходит событие "reconnect" а не "connect", следовательно клиент заново не добавляется в core#client. Сокет тем временем получает сообщение от гейта и не может ему ответить, т.к. про такого клиента он не в курсе. Таким образом core#onHandled спокойно завершается, а гейт упорно ждет ответа на свое сообщение.

В пулл-риквесте сделано следующее:
1. Выделяем ровно один сокет на сервис. Раньше создавался на каждый вызов Service#connect
2. **НЕ УДАЛЯЕМ** ид клиента в core#onClientDisconnected. Удаляем только инстансы.
3. Исправлена ошибка с попыткой вызвать socket.end() при закрытии сокета. Заменено на socket.disconnect()
4. Добавлены отладочные сообщения в ряде мест.
